### PR TITLE
add vmstat_mon plugin

### DIFF
--- a/function_plugins/trg_vmstat_mon
+++ b/function_plugins/trg_vmstat_mon
@@ -1,0 +1,9 @@
+# Can check any vmstat column for activity,
+# but used to monitor for blocked IO in this specific
+# case
+# Usage: --function trg_vmstat_mon --threshold 1 --interval=.01
+
+function trg_plugin()
+{
+  vmstat 1 2 | tail -1 | awk '{if ($2 > 1 && $1 < 1) print 2; else print 0}'
+}


### PR DESCRIPTION
Hi, Fernando

that's about as much as I can contribute... seems you already have the slave monitor plugin and while this vmstat thing isn't very practical in many cases, I found it very useful in a specific condition I was trying to catch (and then get a gdb backtrace).